### PR TITLE
Simplify DecodeError ADT

### DIFF
--- a/modules/config/ConfigDecoders.scala
+++ b/modules/config/ConfigDecoders.scala
@@ -16,6 +16,7 @@ import core._
 
 object ConfigDecoders {
   import ShoconCompat._ //#=shocon
+  import DecodeError._
 
   /** Typesafe config decoders that behave just like the underlying
     * counter part.  For the Shocon backend, some of these are
@@ -46,13 +47,13 @@ object ConfigDecoders {
         try {
           f(config, path).right
         } catch {
-          case e: ConfigException.Missing   => DecodeError.MissingPath(path).left
-          case e: ConfigException.WrongType => DecodeError.WrongType(path, classTag[A].toString).left //#=typesafe
+          case e: ConfigException.Missing   => Missing.atPath(path).left
+          case e: ConfigException.WrongType => WrongType(classTag[A].toString).atPath(path).left //#=typesafe
           //#+shocon
           case e: MatchError if e.getMessage == "null" =>
-            DecodeError.MissingPath(path).left
+            Missing.atPath(path).left
           //#-shocon
-          case other: Throwable             => DecodeError.AtPath(path, DecodeError.Underlying(other)).left
+          case other: Throwable             => Underlying(other).atPath(path).left
         }
       )
 

--- a/modules/core/DecodeError.scala
+++ b/modules/core/DecodeError.scala
@@ -5,6 +5,8 @@
 package classy
 package core
 
+import scala.annotation.tailrec
+
 /** An error that occurred while decoding data
   */
 sealed abstract class DecodeError extends Product with Serializable {
@@ -52,7 +54,18 @@ object DecodeError extends DecodeErrorInstances {
   /** Qualifies a nested error indicating that it occured while decoding
     * a particular path within the source data structure
     */
-  final case class AtPath(path: String, error: DecodeError) extends DecodeError
+  final case class AtPath(path: String, error: DecodeError) extends DecodeError {
+
+    /** Finds the deepest non-`AtPath` error by checking the type of
+      * `error` and repeatedly calling this method on the `error` if
+      * needed
+      */
+    @tailrec def deepError: DecodeError =
+      error match {
+        case error0: AtPath => error0.deepError
+        case _              => error
+      }
+  }
 
   /** Qualifies a nested error indicating that it occurred while decoding
     * a particular index within the source traversable data structure
@@ -150,6 +163,7 @@ object DecodeError extends DecodeErrorInstances {
     case (oneA, oneB) =>
       Or(oneA, oneB :: Nil)
   }
+
 }
 
 private[core] sealed trait DecodeErrorInstances {

--- a/modules/core/DecodeError.scala
+++ b/modules/core/DecodeError.scala
@@ -31,23 +31,23 @@ object DecodeError extends DecodeErrorInstances {
     */
   sealed trait LeafDecodeError extends DecodeError
 
-  /** A value at a `path` was required but not found in the source data
-    * structure
+  /** A value was required but not found in the source data structure
     */
-  final case class MissingPath(path: String) extends LeafDecodeError
+  final case object Missing extends LeafDecodeError
 
-  /** A value was found at `path` but was the type was incorrect
+  /** A value was present but was the type was incorrect
     */
-  final case class WrongType(path: String, expected: String, got: Option[String] = None) extends LeafDecodeError
+  final case class WrongType(expected: String, got: Option[String] = None)
+    extends LeafDecodeError
 
-  /** A value was found at `path` but was truncated during strict
-    * decoding.
+  /** A value was present and decoded but was truncated during the
+    * decoding process.
     *
     * This error typically occurs when strict decoding is used against
     * a backend implementation that normally defaults to lossy decoding
     * that truncates values (generally numeric).
     */
-  final case class Truncated(path: String, raw: String, result: String) extends LeafDecodeError
+  final case class Truncated(raw: String, result: String) extends LeafDecodeError
 
   /** Qualifies a nested error indicating that it occured while decoding
     * a particular path within the source data structure

--- a/modules/core/Decoder.scala
+++ b/modules/core/Decoder.scala
@@ -19,6 +19,7 @@ trait Decoder[A, B] extends Serializable {
   def decode(a: A): Either[DecodeError, B]
 
   import Decoder.instance
+  import DecodeError._
 
   /** Construct a new decoder by mapping the output of this decoder
     */
@@ -103,8 +104,8 @@ trait Decoder[A, B] extends Serializable {
     */
   final def optional: Decoder[A, Option[B]] =
     instance(input => decode(input).fold(_ match {
-      case _: DecodeError.MissingPath => None.right
-      case other                      => other.left
+      case AtPath(_, Missing) => None.right
+      case other              => other.left
     }, _.some.right))
 
   /** Constructs a new decoder that falls back to a default

--- a/modules/core/Decoder.scala
+++ b/modules/core/Decoder.scala
@@ -108,11 +108,31 @@ trait Decoder[A, B] extends Serializable {
       case other              => other.left
     }, _.some.right))
 
+  /** Constructs a new decoder that optionally decodes a value. Deep
+    * errors other than a missing value still cause the resulting
+    * decoder to fail.
+    *
+    * @see [[DecodeError.AtPath.deepError]]
+    */
+  final def deepOptional: Decoder[A, Option[B]] =
+    instance(input => decode(input).fold(_ match {
+      case e: AtPath if e.deepError == Missing => None.right
+      case other                               => other.left
+    }, _.some.right))
+
   /** Constructs a new decoder that falls back to a default
     * value if a missing value error occurs.
     */
   final def withDefault(default: B): Decoder[A, B] =
     optional.map(_ getOrElse default)
+
+  /** Constructs a new decoder that falls back to a default
+    * value if a deep missing value error occurs.
+    *
+    * @see [[DecodeError.AtPath.deepError]]
+    */
+  final def withDeepDefault(default: B): Decoder[A, B] =
+    deepOptional.map(_ getOrElse default)
 
   /** Constructs a new decoder that falls back to a value if _any_ error
     * occurs.

--- a/modules/docs/src/main/tut/getting-started.md
+++ b/modules/docs/src/main/tut/getting-started.md
@@ -64,7 +64,7 @@ a `Map` or a `Config` object.
 
 ```tut:silent
 def decodeString(path: String): Decoder[Map[String, String], String] =
-  Decoder.instance(_.get(path).toRight(DecodeError.MissingPath(path)))
+  Decoder.instance(_.get(path).toRight(DecodeError.Missing.atPath(path)))
 
 val decodeA = decodeString("a")
 val decodeB = decodeString("b")

--- a/modules/testing/DecoderChecks.scala
+++ b/modules/testing/DecoderChecks.scala
@@ -40,6 +40,16 @@ object DecoderChecks {
       case Right(b)                 => dab.optional.decode(a) ?= b.some.right
     }
 
+  def checkDeepOptional[A, B](
+    dab: Decoder[A, B],
+    a: A
+  ): Prop =
+    dab.decode(a) match {
+      case Left(e: AtPath) if e.deepError == Missing => dab.deepOptional.decode(a) ?= None.right
+      case Left(e)                                   => dab.deepOptional.decode(a) ?= e.left
+      case Right(b)                                  => dab.deepOptional.decode(a) ?= b.some.right
+    }
+
   def checkWithDefault[A, B](
     dab: Decoder[A, B],
     a: A,
@@ -51,11 +61,28 @@ object DecoderChecks {
       case Right(b)                 => dab.withDefault(b0).decode(a) ?= b.right
     }
 
+  def checkWithDeepDefault[A, B](
+    dab: Decoder[A, B],
+    a: A,
+    b0: B
+  ): Prop =
+    dab.decode(a) match {
+      case Left(e: AtPath) if e.deepError == Missing => dab.withDeepDefault(b0).decode(a) ?= b0.right
+      case Left(e)                                   => dab.withDeepDefault(b0).decode(a) ?= e.left
+      case Right(b)                                  => dab.withDeepDefault(b0).decode(a) ?= b.right
+    }
+
   def checkOptionalDefaultConsistency[A, B](
     dab: Decoder[A, B],
     a: A,
     b0: B
   ): Prop = dab.optional.decode(a).map(_ getOrElse b0) ?= dab.withDefault(b0).decode(a)
+
+  def checkDeepOptionalDeepDefaultConsistency[A, B](
+    dab: Decoder[A, B],
+    a: A,
+    b0: B
+  ): Prop = dab.deepOptional.decode(a).map(_ getOrElse b0) ?= dab.withDeepDefault(b0).decode(a)
 
   def checkAnd[A, B, C](
     dab: Decoder[A, B],
@@ -76,12 +103,12 @@ object DecoderChecks {
   }
 
   def positive[A: Arbitrary, B: Arbitrary](
-    decoder: Decoder[A, B])(fba: B => A)(implicit ArbBtoB: Arbitrary[B => B]): Properties =
+    decoder: Decoder[A, B])(fba: B => A)(implicit ArbBtoB: Arbitrary[B => B], readAtoA: Read[A, A]): Properties =
     positive[A, B]((b: B) => (fba(b), decoder))
 
   def positive[A: Arbitrary, B: Arbitrary](
     make: B => (A, Decoder[A, B])
-  )(implicit ArbBtoB: Arbitrary[B => B]): Properties = properties("operations") { self =>
+  )(implicit ArbBtoB: Arbitrary[B => B], readAtoA: Read[A, A]): Properties = properties("operations") { self =>
     import self._
 
     // format: OFF
@@ -109,6 +136,15 @@ object DecoderChecks {
       a != na ==> checkOptional(dab, na)
     }
 
+    property("deepOptional") = forAll(
+      "decoder seed" |: arbitrary[B],
+      "bad input"    |: arbitrary[A],
+      "paths"        |: arbitrary[List[String]]
+    ) { (b, na, paths) =>
+      val (a, dab) = make(b)
+      a != na ==> checkDeepOptional(paths.foldLeft(dab)(_ atPath _), na)
+    }
+
     property("withDefault") = forAll(
       "decoder seed" |: arbitrary[B],
       "bad input"    |: arbitrary[A],
@@ -118,6 +154,16 @@ object DecoderChecks {
       a != na ==> checkWithDefault(dab, na, db)
     }
 
+    property("withDeepDefault") = forAll(
+      "decoder seed" |: arbitrary[B],
+      "bad input"    |: arbitrary[A],
+      "default"      |: arbitrary[B],
+      "paths"        |: arbitrary[List[String]]
+    ) { (sb, na, db, paths) =>
+      val (a, dab) = make(sb)
+      a != na ==> checkWithDeepDefault(paths.foldLeft(dab)(_ atPath _), na, db)
+    }
+
     property("optional/withDefault consistency") =forAll(
       "result"    |: arbitrary[B],
       "bad input" |: arbitrary[A],
@@ -125,6 +171,17 @@ object DecoderChecks {
     ) { (b, na, db) =>
       val (a, dab) = make(b)
       a != na ==> checkOptionalDefaultConsistency(dab, a, b)
+    }
+
+    property("deepOptional/withDeepDefault consistency") =forAll(
+      "result"    |: arbitrary[B],
+      "bad input" |: arbitrary[A],
+      "default"   |: arbitrary[B],
+      "paths"     |: arbitrary[List[String]]
+    ) { (b, na, db, paths) =>
+      val (a, dab) = make(b)
+      a != na ==> checkDeepOptionalDeepDefaultConsistency(
+        paths.foldLeft(dab)(_ atPath _), a, b)
     }
 
     property("and") = forAll(

--- a/modules/testing/DecoderChecks.scala
+++ b/modules/testing/DecoderChecks.scala
@@ -35,9 +35,9 @@ object DecoderChecks {
     a: A
   ): Prop =
     dab.decode(a) match {
-      case Left(_: MissingPath) => dab.optional.decode(a) ?= None.right
-      case Left(e)              => dab.optional.decode(a) ?= e.left
-      case Right(b)             => dab.optional.decode(a) ?= b.some.right
+      case Left(AtPath(_, Missing)) => dab.optional.decode(a) ?= None.right
+      case Left(e)                  => dab.optional.decode(a) ?= e.left
+      case Right(b)                 => dab.optional.decode(a) ?= b.some.right
     }
 
   def checkWithDefault[A, B](
@@ -46,9 +46,9 @@ object DecoderChecks {
     b0: B
   ): Prop =
     dab.decode(a) match {
-      case Left(_: MissingPath) => dab.withDefault(b0).decode(a) ?= b0.right
-      case Left(e)              => dab.withDefault(b0).decode(a) ?= e.left
-      case Right(b)             => dab.withDefault(b0).decode(a) ?= b.right
+      case Left(AtPath(_, Missing)) => dab.withDefault(b0).decode(a) ?= b0.right
+      case Left(e)                  => dab.withDefault(b0).decode(a) ?= e.left
+      case Right(b)                 => dab.withDefault(b0).decode(a) ?= b.right
     }
 
   def checkOptionalDefaultConsistency[A, B](

--- a/modules/tests-config/GenericConfigDecoderErrorProperties.scala
+++ b/modules/tests-config/GenericConfigDecoderErrorProperties.scala
@@ -52,25 +52,29 @@ class GenericConfigDecoderErrorProperties extends Properties("generic ConfigDeco
 
   property("decode foo error 1") =
     fooDecoder.decode("wrong { }") ?=
-      MissingPath("foo").left
+      AtPath("foo",
+        Missing).left
 
   property("decode foo error 1") =
     fooDecoder.decode("foo { }") ?=
       AtPath("foo",
-        MissingPath("bar")).left
+        AtPath("bar",
+          Missing)).left
 
   property("decode foo error 1") =
     fooDecoder.decode("foo { bar {} }") ?=
       AtPath("foo",
         AtPath("bar",
-           MissingPath("baz"))).left
+          AtPath("baz",
+            Missing))).left
 
   property("decode foo error 1") =
     fooDecoder.decode("foo { bar { baz {} } }") ?=
       AtPath("foo",
         AtPath("bar",
           AtPath("baz",
-            MissingPath("zip")))).left
+            AtPath("zip",
+              Missing)))).left
 
   import ShapeADT._
   val shapeDecoder = ConfigDecoder[Shape].fromString
@@ -79,41 +83,41 @@ class GenericConfigDecoderErrorProperties extends Properties("generic ConfigDeco
   property("decode shape errors") =
     shapeDecoder.decode("wrong {}") ?=
       Or(
-        MissingPath("circle"),
-        MissingPath("rectangle"),
-        MissingPath("regularPolygon"),
-        MissingPath("square"),
-        MissingPath("triangle")).left
+        AtPath("circle", Missing),
+        AtPath("rectangle", Missing),
+        AtPath("regularPolygon", Missing),
+        AtPath("square", Missing),
+        AtPath("triangle", Missing)).left
 
   property("decode shape errors with nested error") =
     shapeDecoder.decode("circle { stillWrong: {} }") ?=
       Or(
         AtPath("circle",
-          MissingPath("radius")),
-        MissingPath("rectangle"),
-        MissingPath("regularPolygon"),
-        MissingPath("square"),
-        MissingPath("triangle")).left
+          AtPath("radius", Missing)),
+        AtPath("rectangle", Missing),
+        AtPath("regularPolygon", Missing),
+        AtPath("square", Missing),
+        AtPath("triangle", Missing)).left
 
   property("decode shapes error") =
     shapesDecoder.decode("wrong {}") ?=
-      MissingPath("shapes").left
+      AtPath("shapes", Missing).left
 
   property("decode shapes errors with nested errors 1") =
     shapesDecoder.decode("shapes: [{}, {}]") ?=
       AtPath("shapes", And(
         AtIndex(0, Or(
-          MissingPath("circle"),
-          MissingPath("rectangle"),
-          MissingPath("regularPolygon"),
-          MissingPath("square"),
-          MissingPath("triangle"))),
+          AtPath("circle", Missing),
+          AtPath("rectangle", Missing),
+          AtPath("regularPolygon", Missing),
+          AtPath("square", Missing),
+          AtPath("triangle", Missing))),
         AtIndex(1, Or(
-          MissingPath("circle"),
-          MissingPath("rectangle"),
-          MissingPath("regularPolygon"),
-          MissingPath("square"),
-          MissingPath("triangle"))))).left
+          AtPath("circle", Missing),
+          AtPath("rectangle", Missing),
+          AtPath("regularPolygon", Missing),
+          AtPath("square", Missing),
+          AtPath("triangle", Missing))))).left
 
   property("decode shapes errors with nested errors 2") =
     shapesDecoder.decode("""
@@ -127,20 +131,20 @@ class GenericConfigDecoderErrorProperties extends Properties("generic ConfigDeco
       AtPath("shapes",
         And(
           AtIndex(1, Or(
-            MissingPath("circle"),
+            AtPath("circle", Missing),
             AtPath("rectangle", And(
-              MissingPath("length"),
-              MissingPath("width"))),
-            MissingPath("regularPolygon"),
-            MissingPath("square"),
-            MissingPath("triangle"))),
+              AtPath("length", Missing),
+              AtPath("width", Missing))),
+            AtPath("regularPolygon", Missing),
+            AtPath("square", Missing),
+            AtPath("triangle", Missing))),
           AtIndex(3, Or(
-            MissingPath("circle"),
-            MissingPath("rectangle"),
-            MissingPath("regularPolygon"),
+            AtPath("circle", Missing),
+            AtPath("rectangle", Missing),
+            AtPath("regularPolygon", Missing),
             AtPath("square",
-              MissingPath("dimension")),
-            MissingPath("triangle")))
+              AtPath("dimension", Missing)),
+            AtPath("triangle", Missing)))
         )).left
 
 }

--- a/modules/tests-config/GenericConfigDecoderShapes.scala
+++ b/modules/tests-config/GenericConfigDecoderShapes.scala
@@ -66,8 +66,8 @@ class GenericConfigDecoderShapes extends Properties("ConfigDecoder generic shape
   val nestNest = "nn" -> ConfigDecoder[NestNest.Paddywhack].fromString.map(_ => ())
 
   val ios: List[(String, DecodeError)] = List(
-    "          " -> MissingPath("zapZip"),
-    "zapZip: {}" -> AtPath("zapZip", Or(MissingPath("zap"), MissingPath("zip")))
+    "          " -> AtPath("zapZip", Missing),
+    "zapZip: {}" -> AtPath("zapZip", Or(AtPath("zap", Missing), AtPath("zip", Missing)))
   )
 
   def check(

--- a/modules/tests/DecodeErrorProperties.scala
+++ b/modules/tests/DecodeErrorProperties.scala
@@ -56,14 +56,14 @@ class DecodeErrorProperties extends Properties("DecodeError") {
       arbitrary[String] :| "path",
       arbitrary[String] :| "missing path"
     )((path, missingPath) =>
-        MissingPath(missingPath).atPath(path) ?=
-          AtPath(path, MissingPath(missingPath)))
+        Missing.atPath(missingPath).atPath(path) ?=
+          AtPath(path, AtPath(missingPath, Missing)))
 
   property("atIndex") =
     forAll(
       arbitrary[Int] :| "index",
       arbitrary[String] :| "missing path"
     )((index, missingPath) =>
-        MissingPath(missingPath).atIndex(index) ?=
-          AtIndex(index, MissingPath(missingPath)))
+        Missing.atPath(missingPath).atIndex(index) ?=
+          AtIndex(index, AtPath(missingPath, Missing)))
 }

--- a/modules/tests/DecodeErrorProperties.scala
+++ b/modules/tests/DecodeErrorProperties.scala
@@ -66,4 +66,14 @@ class DecodeErrorProperties extends Properties("DecodeError") {
     )((index, missingPath) =>
         Missing.atPath(missingPath).atIndex(index) ?=
           AtIndex(index, AtPath(missingPath, Missing)))
+
+  property("AtPath.deepError") =
+    forAll(
+      genLeaf :| "deep error",
+      arbitrary[String] :| "paths head",
+      arbitrary[List[String]] :| "paths tail"
+    )((error, pathHead, pathTail) =>
+        pathTail.foldLeft(
+          error.atPath(pathHead)
+        )(_ atPath _).deepError ?= error)
 }

--- a/modules/tests/DecoderProperties.scala
+++ b/modules/tests/DecoderProperties.scala
@@ -23,6 +23,11 @@ class DecoderProperties extends Properties("Decoder") {
       ArbDAB.arbitrary.map(value => Decoder.const[A, B](value)),
       ArbDecodeError.arbitrary.map(value => Decoder.fail[A, B](value))))
 
+  // a hack to make the "deep" DecoderChecks compile and pass for
+  // primitive decoders
+  implicit val timeToCheat: Read[String, String] =
+    Read.instance(_ => Decoder.instance(_.right))
+
   include(
     DecoderChecks.positive(Decoder.instance[String, String](v => v.right))(v => v),
     "identity ")


### PR DESCRIPTION
This simplifies the DecodeError ADT by removing path from several of the leaf errors in favor of just using the `AtPath` error to describe paths.

This should make it easier to write decoders between primitive types-- such as `Decoder[String, FiniteDuration]` and then use those automatically across modules.