### PR TITLE
Add decoder for FiniteDuration

### DIFF
--- a/modules/config/ConfigDecoders.scala
+++ b/modules/config/ConfigDecoders.scala
@@ -9,6 +9,7 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigException
 
 import scala.collection.JavaConverters._
+import scala.concurrent.duration.FiniteDuration
 import scala.reflect.{ ClassTag, classTag } //#=typesafe
 import scala.reflect.ClassTag               //#=shocon
 
@@ -23,21 +24,22 @@ object ConfigDecoders {
     */
   object std {
     // format: OFF
-    def config     (path: String): ConfigDecoder[Config]        = instance(path)(_ getConfig _)
-    def string     (path: String): ConfigDecoder[String]        = instance(path)(_ getString _)
-    def number     (path: String): ConfigDecoder[Number]        = instance(path)(_ getNumber _)      //#=typesafe
-    def boolean    (path: String): ConfigDecoder[Boolean]       = instance(path)(_ getBoolean _)
-    def int        (path: String): ConfigDecoder[Int]           = instance(path)(_ getInt _)
-    def long       (path: String): ConfigDecoder[Long]          = instance(path)(_ getLong _)
-    def double     (path: String): ConfigDecoder[Double]        = instance(path)(_ getDouble _)
+    def config        (path: String): ConfigDecoder[Config]         = instance(path)(_ getConfig _)
+    def string        (path: String): ConfigDecoder[String]         = instance(path)(_ getString _)
+    def number        (path: String): ConfigDecoder[Number]         = instance(path)(_ getNumber _)      //#=typesafe
+    def boolean       (path: String): ConfigDecoder[Boolean]        = instance(path)(_ getBoolean _)
+    def int           (path: String): ConfigDecoder[Int]            = instance(path)(_ getInt _)
+    def long          (path: String): ConfigDecoder[Long]           = instance(path)(_ getLong _)
+    def double        (path: String): ConfigDecoder[Double]         = instance(path)(_ getDouble _)
+    def finiteDuration(path: String): ConfigDecoder[FiniteDuration] = instance(path)(_ getDuration _)
 
-    def configList (path: String): ConfigDecoder[List[Config]]  = instance(path)(_ getConfigList _)
-    def stringList (path: String): ConfigDecoder[List[String]]  = instance(path)(_ getStringList _)
-    def numberList (path: String): ConfigDecoder[List[Number]]  = instance(path)(_ getNumberList _)  //#=typesafe
-    def booleanList(path: String): ConfigDecoder[List[Boolean]] = instance(path)(_ getBooleanList _)
-    def intList    (path: String): ConfigDecoder[List[Int]]     = instance(path)(_ getIntList _)
-    def longList   (path: String): ConfigDecoder[List[Long]]    = instance(path)(_ getLongList _)
-    def doubleList (path: String): ConfigDecoder[List[Double]]  = instance(path)(_ getDoubleList _)
+    def configList    (path: String): ConfigDecoder[List[Config]]   = instance(path)(_ getConfigList _)
+    def stringList    (path: String): ConfigDecoder[List[String]]   = instance(path)(_ getStringList _)
+    def numberList    (path: String): ConfigDecoder[List[Number]]   = instance(path)(_ getNumberList _)  //#=typesafe
+    def booleanList   (path: String): ConfigDecoder[List[Boolean]]  = instance(path)(_ getBooleanList _)
+    def intList       (path: String): ConfigDecoder[List[Int]]      = instance(path)(_ getIntList _)
+    def longList      (path: String): ConfigDecoder[List[Long]]     = instance(path)(_ getLongList _)
+    def doubleList    (path: String): ConfigDecoder[List[Double]]   = instance(path)(_ getDoubleList _)
     // format: ON
 
     @inline private[this] def instance[A: ClassTag](
@@ -58,6 +60,9 @@ object ConfigDecoders {
 
     @inline private[this] implicit def convertLists[A, B](j: java.util.List[A]): List[B] =
       j.asScala.toList.map(_.asInstanceOf[B])
+
+    @inline private[this] implicit def convertDuration(j: java.time.Duration): FiniteDuration =
+      scala.concurrent.duration.FiniteDuration(j.toNanos, java.util.concurrent.TimeUnit.NANOSECONDS)
   }
 
   /** Typesafe config decoders that prevent narrowing of configuration

--- a/modules/config/package.scala
+++ b/modules/config/package.scala
@@ -81,19 +81,20 @@ package object config {
   // implicit proxies for the defaults for generic derivation
   // format: OFF
   import ConfigDecoders.std._
-  implicit val defaultConfigReadConfig      = Read.instance(config)
-  implicit val defaultConfigReadString      = Read.instance(string)
-  implicit val defaultConfigReadNumber      = Read.instance(number)      //#=typesafe
-  implicit val defaultConfigReadBoolean     = Read.instance(boolean)
-  implicit val defaultConfigReadInt         = Read.instance(int)
-  implicit val defaultConfigReadLong        = Read.instance(long)
-  implicit val defaultConfigReadDouble      = Read.instance(double)
+  implicit val defaultConfigReadConfig         = Read.instance(config)
+  implicit val defaultConfigReadString         = Read.instance(string)
+  implicit val defaultConfigReadNumber         = Read.instance(number)      //#=typesafe
+  implicit val defaultConfigReadBoolean        = Read.instance(boolean)
+  implicit val defaultConfigReadFiniteDuration = Read.instance(finiteDuration)
+  implicit val defaultConfigReadInt            = Read.instance(int)
+  implicit val defaultConfigReadLong           = Read.instance(long)
+  implicit val defaultConfigReadDouble         = Read.instance(double)
 
-  implicit val defaultConfigReadConfigList  = Read.instance(configList)
-  implicit val defaultConfigReadStringList  = Read.instance(stringList)
-  implicit val defaultConfigReadNumberList  = Read.instance(numberList)  //#=typesafe
-  implicit val defaultConfigReadBooleanList = Read.instance(booleanList)
-  implicit val defaultConfigReadIntList     = Read.instance(intList)
-  implicit val defaultConfigReadLongList    = Read.instance(longList)
-  implicit val defaultConfigReadDoubleList  = Read.instance(doubleList)
+  implicit val defaultConfigReadConfigList     = Read.instance(configList)
+  implicit val defaultConfigReadStringList     = Read.instance(stringList)
+  implicit val defaultConfigReadNumberList     = Read.instance(numberList)  //#=typesafe
+  implicit val defaultConfigReadBooleanList    = Read.instance(booleanList)
+  implicit val defaultConfigReadIntList        = Read.instance(intList)
+  implicit val defaultConfigReadLongList       = Read.instance(longList)
+  implicit val defaultConfigReadDoubleList     = Read.instance(doubleList)
 }

--- a/modules/tests-config/example1.scala
+++ b/modules/tests-config/example1.scala
@@ -5,7 +5,9 @@
 package classy_generic_examples
 
 import com.typesafe.config.ConfigFactory
+
 import scala.Predef._
+import scala.concurrent.duration.FiniteDuration
 
 object Example1 extends App {
 
@@ -15,12 +17,14 @@ object Example1 extends App {
     a: String = "a's default value",
     b: Option[Int],
     c: List[String],
+    d: FiniteDuration,
     bars: List[Bar]
   )
 
   val typesafeConfig = ConfigFactory parseString """
    | a : okay
    | c = ["hello", "world"]
+   | b = 20s
    | bars = [{ value: hello }]
    |""".stripMargin
 
@@ -54,11 +58,12 @@ object Example1 extends App {
     val decodeA    = readConfig[String]("a").withDefault("a's default value")
     val decodeB    = readConfig[Int]("b").optional
     val decodeC    = readConfig[List[String]]("c")
+    val decodeD    = readConfig[FiniteDuration]("d")
     val decodeBar  = readConfig[String]("value").map(value => Bar(value))
     val decodeBars = readConfig[List[Config]]("bars") andThen decodeBar.sequence[List]
 
-    implicit val decodeFoo = (decodeA and decodeB and decodeC and decodeBars).map {
-      case (((a, b), c), bar) => Foo(a, b, c, bar)
+    implicit val decodeFoo = (decodeA and decodeB and decodeC and decodeD and decodeBars).map {
+      case ((((a, b), c), d), bar) => Foo(a, b, c, d, bar)
     }
 
     val res = ConfigDecoder[Foo].decode(typesafeConfig)


### PR DESCRIPTION
This pull request adds a new decoder for `scala.concurrent.duration.FiniteDuration` values.