### PR TITLE
Add tailRecM and MonadError instance for Decoder

### DIFF
--- a/modules/cats/package.scala
+++ b/modules/cats/package.scala
@@ -6,6 +6,9 @@ package classy
 
 import _root_.cats._
 import _root_.cats.data.Kleisli
+import _root_.cats.instances.either._
+import _root_.cats.syntax.either._
+import scala.annotation.tailrec
 
 import core._
 
@@ -26,8 +29,8 @@ package object cats {
     // unidoc unless used in conjuction with a scaladoc @usecase
   }
 
-  implicit def decoderMonadInstance[Z]: Monad[Decoder[Z, ?]] =
-    new Monad[Decoder[Z, ?]] {
+  implicit def decoderMonadErrorInstance[Z]: MonadError[Decoder[Z, ?], DecodeError] =
+    new MonadError[Decoder[Z, ?], DecodeError] {
 
       override def map[A, B](a: Decoder[Z, A])(f: A => B): Decoder[Z, B] =
         a.map(f)
@@ -38,18 +41,38 @@ package object cats {
       def flatMap[A, B](fa: Decoder[Z, A])(f: A => Decoder[Z, B]): Decoder[Z, B] =
         fa.flatMap(f)
 
-      // Currently *not* stack safe
-      def tailRecM[A, B](a: A)(f: A => Decoder[Z, Either[A, B]]): Decoder[Z, B] =
-        f(a).flatMap {
-          case Left(a1) => tailRecM(a1)(f)
-          case Right(b) => Decoder.const(b)
+      final def tailRecM[A, B](a: A)(f: A => Decoder[Z, Either[A, B]]): Decoder[Z, B] =
+        new Decoder[Z, B] {
+          @tailrec
+          private[this] def step(a1: A, z: Z): Either[DecodeError, B] = f(a1)(z) match {
+            case l @ Left(_) => l.rightCast[B]
+            case Right(x) =>
+              x match {
+                case Left(a2) => step(a2, z)
+                case r @ Right(_) => r.leftCast[DecodeError]
+              }
+          }
+
+          final def apply(z: Z): Either[DecodeError, B] = step(a, z)
+        }
+
+      final def raiseError[A](e: DecodeError): Decoder[Z, A] =
+        Decoder.fail(e)
+
+      final def handleErrorWith[A](fa: Decoder[Z, A])(f: DecodeError => Decoder[Z, A]): Decoder[Z, A] =
+        Decoder.instance { z =>
+          MonadError[Either[DecodeError, ?], DecodeError].handleErrorWith(fa.apply(z))(err => f(err)(z))
         }
     }
 
-  implicit val decodeErrorEq: Eq[DecodeError] =
-    new Eq[DecodeError] {
-      def eqv(x: DecodeError, y: DecodeError): Boolean = x == y
+  implicit def decoderSemigroupKInstance[Z]: SemigroupK[Decoder[Z, ?]] =
+    new SemigroupK[Decoder[Z, ?]] {
+      def combineK[A](d1: Decoder[Z, A], d2: Decoder[Z, A]): Decoder[Z, A] =
+        d1 or d2
     }
+
+  implicit val decodeErrorEq: Eq[DecodeError] =
+    Eq.fromUniversalEquals
 
   object DecodeErrorMonoid {
     object and {

--- a/modules/tests/DecoderProperties.scala
+++ b/modules/tests/DecoderProperties.scala
@@ -23,6 +23,9 @@ class DecoderProperties extends Properties("Decoder") {
       ArbDAB.arbitrary.map(value => Decoder.const[A, B](value)),
       ArbDecodeError.arbitrary.map(value => Decoder.fail[A, B](value))))
 
+  implicit val cogenDecodeError: Cogen[DecodeError] =
+    Cogen((_: DecodeError).hashCode.toLong)
+
   // a hack to make the "deep" DecoderChecks compile and pass for
   // primitive decoders
   implicit val timeToCheat: Read[String, String] =
@@ -35,6 +38,6 @@ class DecoderProperties extends Properties("Decoder") {
   include(DecoderChecks.positive(
     (result: String) => ("", Decoder.const[String, String](result))))
 
-  include(MonadTests[Decoder[String, ?]].stackUnsafeMonad[String, String, String].all)
-
+  include(MonadErrorTests[Decoder[String, ?], DecodeError].monadError[String, String, String].all)
+  include(SemigroupKTests[Decoder[String, ?]].semigroupK[String].all)
 }


### PR DESCRIPTION
I based the `tailRecM` and `handleErrorWith` implementations on the instances of `Either` and `io.circe.Decoder`.