### PR TITLE
Travis: moving from Precise to Trusty dist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
-dist: precise
 sudo: required
+dist: trusty
 jdk:
 - oraclejdk8
 scala:


### PR DESCRIPTION
Ubuntu Precise 12.04 LTS End of Life:

https://blog.travis-ci.com/2017-04-17-precise-EOL
https://blog.travis-ci.com/2017-05-04-precise-image-updates