### PR TITLE
Add support for kebab-case

### DIFF
--- a/modules/generic/src/main/scala/classy/generic/derive/MkDecoder.scala
+++ b/modules/generic/src/main/scala/classy/generic/derive/MkDecoder.scala
@@ -310,19 +310,19 @@ object NamingStrategy {
   object LowerSnakeCase extends SplitJoinNamingStrategy(StringSplitter.split)(
     _.map(_.toLowerCase).mkString("_"))
 
-  /** A basic kebab case (`Kebab_case`) naming strategy that preserves
+  /** A basic kebab case (`Kebab-case`) naming strategy that preserves
     * character case
     */
   object KebabCase extends SplitJoinNamingStrategy(StringSplitter.split)(
     _.mkString("-"))
 
-  /** A basic kebab case (`KEBAB_CASE`) naming strategy that maps all
+  /** A basic kebab case (`KEBAB-CASE`) naming strategy that maps all
     * characters to uppercase
     */
   object UpperKebabCase extends SplitJoinNamingStrategy(StringSplitter.split)(
     _.map(_.toUpperCase).mkString("-"))
 
-  /** A basic kebab case (`kebab_case`) naming strategy that maps all
+  /** A basic kebab case (`kebab-case`) naming strategy that maps all
     * characters to lowercase
     */
   object LowerKebabCase extends SplitJoinNamingStrategy(StringSplitter.split)(

--- a/modules/generic/src/main/scala/classy/generic/derive/MkDecoder.scala
+++ b/modules/generic/src/main/scala/classy/generic/derive/MkDecoder.scala
@@ -310,6 +310,24 @@ object NamingStrategy {
   object LowerSnakeCase extends SplitJoinNamingStrategy(StringSplitter.split)(
     _.map(_.toLowerCase).mkString("_"))
 
+  /** A basic kebab case (`Kebab_case`) naming strategy that preserves
+    * character case
+    */
+  object KebabCase extends SplitJoinNamingStrategy(StringSplitter.split)(
+    _.mkString("-"))
+
+  /** A basic kebab case (`KEBAB_CASE`) naming strategy that maps all
+    * characters to uppercase
+    */
+  object UpperKebabCase extends SplitJoinNamingStrategy(StringSplitter.split)(
+    _.map(_.toUpperCase).mkString("-"))
+
+  /** A basic kebab case (`kebab_case`) naming strategy that maps all
+    * characters to lowercase
+    */
+  object LowerKebabCase extends SplitJoinNamingStrategy(StringSplitter.split)(
+    _.map(_.toLowerCase).mkString("-"))
+
   private[this] def cap(input: String): String = {
     var chars = input.toCharArray()
     chars(0) = Character.toUpperCase(chars(0))

--- a/modules/tests/src/test/scala/classy/NamingStrategyTests.scala
+++ b/modules/tests/src/test/scala/classy/NamingStrategyTests.scala
@@ -75,4 +75,30 @@ class NamingStrategyTests extends Properties("NamingStrategyTests") {
       Entry("Helloworld", "helloworld")
     ))
 
+  property("KebabCase") = check(
+    KebabCase,
+    List(
+      Entry("hello", "hello"),
+      Entry("HelloWorld", "Hello-World"),
+      Entry("helloWorld", "hello-World"),
+      Entry("Helloworld", "Helloworld")
+    ))
+
+  property("UpperKebabCase") = check(
+    UpperKebabCase,
+    List(
+      Entry("hello", "HELLO"),
+      Entry("HelloWorld", "HELLO-WORLD"),
+      Entry("helloWorld", "HELLO-WORLD"),
+      Entry("Helloworld", "HELLOWORLD")
+    ))
+
+  property("LowerKebabCase") = check(
+    LowerKebabCase,
+    List(
+      Entry("hello", "hello"),
+      Entry("HelloWorld", "hello-world"),
+      Entry("helloWorld", "hello-world"),
+      Entry("Helloworld", "helloworld")
+    ))
 }


### PR DESCRIPTION
The ~Typesafe~Lightbend [docs](https://github.com/lightbend/config#uses-of-substitutions) use this format, as does [Akka](https://doc.akka.io/docs/akka/current/scala/general/configuration.html#listing-of-the-reference-configuration), so it's useful to me to support this format and keep my config consistent. Although it's a trivial thing to implement in projects instead of adding to the library, it seems fairly wide-spread, so hopefully it's useful.

I'd be happy to change the name to "lisp-case" or "spinal-case" or anything else.